### PR TITLE
The cache check now targets correct buffer

### DIFF
--- a/triangle.js
+++ b/triangle.js
@@ -9,7 +9,7 @@ var TriangleCache = new weakMap()
 function createABigTriangle(gl) {
 
   var triangleVAO = TriangleCache.get(gl)
-  if(!triangleVAO || !gl.isBuffer(triangleVAO._triangleBuffer.buffer)) {
+  if(!triangleVAO || !gl.isBuffer(triangleVAO._triangleBuffer.handle)) {
     var buf = createBuffer(gl, new Float32Array([-1, -1, -1, 4, 4, -1]))
     triangleVAO = createVAO(gl, [
       { buffer: buf,


### PR DESCRIPTION
`gl-buffer` has a property called `handle` not `buffer`. This was causing the cache validation to fail
