### PR TITLE
Fix cache check

### DIFF
--- a/triangle.js
+++ b/triangle.js
@@ -9,7 +9,8 @@ var TriangleCache = new weakMap()
 function createABigTriangle(gl) {
 
   var triangleVAO = TriangleCache.get(gl)
-  if(!triangleVAO || !gl.isBuffer(triangleVAO._triangleBuffer.buffer)) {
+  var handle = triangleVAO && (triangleVAO._triangleBuffer.handle || triangleVAO._triangleBuffer.buffer)
+  if(!handle || !gl.isBuffer(handle)) {
     var buf = createBuffer(gl, new Float32Array([-1, -1, -1, 4, 4, -1]))
     triangleVAO = createVAO(gl, [
       { buffer: buf,


### PR DESCRIPTION
As highlighted by @marklundin in #3, a-big-triangle has been
checking .buffer instead of .handle, and as such creates a
new WebGLBuffer every time it's called.

This fixes the issue, in addition to maintaining backwards
compatability :)
